### PR TITLE
fix gcc conflict on lab machines

### DIFF
--- a/handout/install-riscv-tools.sh
+++ b/handout/install-riscv-tools.sh
@@ -20,7 +20,7 @@ rm -f riscv64-unknown-elf-gcc-8.3.0-2019.08.0-x86_64-linux-ubuntu14.tar.gz &
 # setshell environment variables
 echo "cpsc3200(){" >> ~/.bashrc
 echo "   export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$QEMUDIR/lib:$GCCDIR/lib" >> ~/.bashrc
-echo "   export PATH=$PATH:$QEMUDIR/bin:$GCCDIR/bin" >> ~/.bashrc
+echo "   export PATH=$QEMUDIR/bin:$GCCDIR/bin:$PATH" >> ~/.bashrc
 echo "}" >> ~/.bashrc
 echo "cpsc3200" >> ~/.bashrc
 sync


### PR DESCRIPTION
The lab machines will use the 9.2 version of gcc over the downloaded 8.3 version before.
![fail](https://user-images.githubusercontent.com/43831731/73312016-c409f000-41f5-11ea-9e52-426928d28eab.png)
![Screenshot_2020-01-28_17-31-34](https://user-images.githubusercontent.com/43831731/73312037-cd935800-41f5-11ea-8a54-dad51f61582a.png)
